### PR TITLE
Added constructor check

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ var deepEqual = module.exports = function (actual, expected) {
   if (actual === expected) {
     return true;
 
+  } else if(typeof(expected) == 'function') {
+    return actual.constructor === expected;
+
+  } else if(typeof(actual) == 'function') {
+    return expected.constructor === actual;
+    
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -21,3 +21,11 @@ test('nested nulls', function (t) {
     t.ok(equal([ null, null, null ], [ null, null, null ]));
     t.end();
 });
+
+test('equal with constructor check', function (t) {
+    t.ok(equal(
+        { a : 'str', b: 10, c: [10, true], d: {k: [1121, 2323], d: Number} },
+        { a : String, b: Number, c: [Number, Boolean] , d: {k: Array, d: 10} }
+    ));
+    t.end();
+});


### PR DESCRIPTION
Sometime we need to check only the type of the value. See the below example.

``` js
deepEqual(
        { a : 'str', b: 10, c: [10, true], d: {k: [1121, 2323], d: Number} },
        { a : String, b: Number, c: [Number, Boolean] , d: {k: Array, d: 10} }
);
```
