### PR TITLE
Fixed arguments support for IE8-

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,23 @@ function isUndefinedOrNull(value) {
   return value === null || value === undefined;
 }
 
-function isArguments(object) {
-  return Object.prototype.toString.call(object) == '[object Arguments]';
+var supportsArgumentsClass = (function(){
+  return Object.prototype.toString.call(arguments)
+}) == '[object Arguments]';
+
+if(supportsArgumentsClass) {
+  var isArguments = function(object) {
+    return Object.prototype.toString.call(object) == '[object Arguments]';
+  }
+} else {
+  var isArguments = function(object){
+    return object &&
+      typeof object == 'object' &&
+      typeof object.length == 'number' &&
+      Object.prototype.hasOwnProperty.call(object, 'callee') &&
+      !Object.prototype.propertyIsEnumerable.call(object, 'callee') ||
+      false;
+  }
 }
 
 function objEquiv(a, b, opts) {

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -30,3 +30,18 @@ test('strict equal', function (t) {
     ));
     t.end();
 });
+
+
+test('arguments class', function (t) {
+    t.deepEqual(
+        (function(){return arguments})(1,2,3),
+        (function(){return arguments})(1,2,3),
+        "compares arguments"
+    )
+    t.notDeepEqual(
+        (function(){return arguments})(1,2,3),
+        [1,2,3],
+        "differenciates array and arguments"
+    )
+    t.end();
+});


### PR DESCRIPTION
Old browsers, and especially IE8- do not support the `[object Arguments]` arguments class, and `toString` checking returns `[object Object]`. 
