### PR TITLE
Fixes equality checking for Map objects.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,10 @@
     "max-statements-per-line": [2, { "max": 2 }],
     "strict": 1,
   },
+  "globals": {
+    "WeakMap": false,
+    "WeakSet": false,
+  },
   "overrides": [
     {
       "files": "example/**",

--- a/index.js
+++ b/index.js
@@ -7,10 +7,16 @@ var isArray = require('isarray');
 var isDate = require('is-date-object');
 var whichBoxedPrimitive = require('which-boxed-primitive');
 var callBound = require('es-abstract/helpers/callBound');
+var whichCollection = require('which-collection');
+var getIterator = require('es-get-iterator');
 
 var $getTime = callBound('Date.prototype.getTime');
 var gPO = Object.getPrototypeOf;
 var $objToString = callBound('Object.prototype.toString');
+
+var $mapHas = callBound('Map.prototype.has', true);
+var $mapGet = callBound('Map.prototype.get', true);
+var $setHas = callBound('Set.prototype.has', true);
 
 function deepEqual(actual, expected, options) {
   var opts = options || {};
@@ -62,7 +68,7 @@ function isBuffer(x) {
 }
 
 function objEquiv(a, b, opts) {
-  /* eslint max-statements: [2, 70], max-lines-per-function: [2, 80] */
+  /* eslint max-statements: [2, 100], max-lines-per-function: [2, 120], max-depth: [2, 5] */
   var i, key;
 
   if (typeof a !== typeof b) { return false; }
@@ -136,6 +142,41 @@ function objEquiv(a, b, opts) {
   for (i = ka.length - 1; i >= 0; i--) {
     key = ka[i];
     if (!deepEqual(a[key], b[key], opts)) { return false; }
+  }
+
+  var aCollection = whichCollection(a);
+  var bCollection = whichCollection(b);
+  if (aCollection !== bCollection) {
+    return false;
+  }
+  if (aCollection === 'Map' || aCollection === 'Set') {
+    var iA = getIterator(a);
+    var iB = getIterator(b);
+    var resultA;
+    var resultB;
+    if (aCollection === 'Map') { // aCollection === bCollection
+      var aWithBKey;
+      var bWithAKey;
+      while ((resultA = iA.next()) && (resultB = iB.next()) && !resultA.done && !resultB.done) {
+        if (!$mapHas(a, resultB.value[0]) || !$mapHas(b, resultA.value[0])) { return false; }
+        if (resultA.value[0] === resultB.value[0]) { // optimization: keys are the same, no need to look up values
+          if (!deepEqual(resultA.value[1], resultB.value[1])) { return false; }
+        } else {
+          aWithBKey = $mapGet(a, resultB.value[0]);
+          bWithAKey = $mapGet(b, resultA.value[0]);
+          if (!deepEqual(resultA.value[1], bWithAKey) || !deepEqual(resultB.value[1], aWithBKey)) {
+            return false;
+          }
+        }
+      }
+    } else if (aCollection === 'Set') { // aCollection === bCollection
+      while ((resultA = iA.next()) && (resultB = iB.next()) && !resultA.done && !resultB.done) {
+        if (!$setHas(a, resultB.value) || !$setHas(b, resultA.value)) { return false; }
+      }
+    }
+    if (resultA && resultB && resultA.done !== resultB.done) {
+      return false;
+    }
   }
 
   return true;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "es-abstract": "^1.16.2",
+    "es-get-iterator": "^1.0.1",
     "is-arguments": "^1.0.4",
     "is-date-object": "^1.0.1",
     "is-regex": "^1.0.4",
@@ -37,7 +38,8 @@
     "object-is": "^1.0.1",
     "object-keys": "^1.1.1",
     "regexp.prototype.flags": "^1.2.0",
-    "which-boxed-primitive": "^1.0.1"
+    "which-boxed-primitive": "^1.0.1",
+    "which-collection": "^1.0.0"
   },
   "devDependencies": {
     "@ljharb/eslint-config": "^15.0.2",

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -12,6 +12,16 @@ test('equal', function (t) {
     true,
     false
   );
+
+  t.deepEqualTest(
+    new Map([['a', 1], ['b', 2]]),
+    new Map([['b', 2], ['a', 1]]),
+    'two equal Maps',
+    true,
+    true,
+    false
+  );
+
   t.end();
 });
 
@@ -23,6 +33,23 @@ test('not equal', function (t) {
     false,
     false
   );
+
+  t.deepEqualTest(
+    new Map([['a', [1, 2]]]),
+    new Map([['a', [2, 1]]]),
+    'two Maps with inequal values on the same key',
+    false,
+    false
+  );
+
+  t.deepEqualTest(
+    new Map([['a', 1]]),
+    new Map([['b', 1]]),
+    'two inequal Maps',
+    false,
+    false
+  );
+
   t.end();
 });
 

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -13,25 +13,16 @@ test('equal', function (t) {
     false
   );
 
+  t.end();
+});
+
+test('Maps', { skip: typeof Map !== 'function' }, function (t) {
   t.deepEqualTest(
     new Map([['a', 1], ['b', 2]]),
     new Map([['b', 2], ['a', 1]]),
     'two equal Maps',
     true,
-    true,
-    false
-  );
-
-  t.end();
-});
-
-test('not equal', function (t) {
-  t.deepEqualTest(
-    { x: 5, y: [6] },
-    { x: 5, y: 6 },
-    'two inequal objects are',
-    false,
-    false
+    true
   );
 
   t.deepEqualTest(
@@ -46,6 +37,86 @@ test('not equal', function (t) {
     new Map([['a', 1]]),
     new Map([['b', 1]]),
     'two inequal Maps',
+    false,
+    false
+  );
+
+  t.end();
+});
+
+test('WeakMaps', { skip: typeof WeakMap !== 'function' }, function (t) {
+  t.deepEqualTest(
+    new WeakMap([[Object, null], [Function, true]]),
+    new WeakMap([[Function, true], [Object, null]]),
+    'two equal WeakMaps',
+    true,
+    true
+  );
+
+  t.deepEqualTest(
+    new WeakMap([[Object, null]]),
+    new WeakMap([[Object, true]]),
+    'two WeakMaps with inequal values on the same key',
+    true,
+    true
+  );
+
+  t.deepEqualTest(
+    new WeakMap([[Object, null], [Function, true]]),
+    new WeakMap([[Object, null]]),
+    'two inequal WeakMaps',
+    true,
+    true
+  );
+
+  t.end();
+});
+
+test('Sets', { skip: typeof Set !== 'function' }, function (t) {
+  t.deepEqualTest(
+    new Set(['a', 1, 'b', 2]),
+    new Set(['b', 2, 'a', 1]),
+    'two equal Sets',
+    true,
+    true
+  );
+
+  t.deepEqualTest(
+    new Set(['a', 1]),
+    new Set(['b', 1]),
+    'two inequal Sets',
+    false,
+    false
+  );
+
+  t.end();
+});
+
+test('WeakSets', { skip: typeof WeakSet !== 'function' }, function (t) {
+  t.deepEqualTest(
+    new WeakSet([Object, Function]),
+    new WeakSet([Function, Object]),
+    'two equal WeakSets',
+    true,
+    true
+  );
+
+  t.deepEqualTest(
+    new WeakSet([Object, Function]),
+    new WeakSet([Object]),
+    'two inequal WeakSets',
+    true,
+    true
+  );
+
+  t.end();
+});
+
+test('not equal', function (t) {
+  t.deepEqualTest(
+    { x: 5, y: [6] },
+    { x: 5, y: 6 },
+    'two inequal objects are',
     false,
     false
   );


### PR DESCRIPTION
Currently:
```javascript
// keys are not checked
const equal = require('./index.js')
const a = new Map([['a', 1]])
const b = new Map([['b', 1]])
equal(a, b) // true
// recursive checking for values doesn't work, either
const x = new Map([['a', [1, 2]]])
const y = new Map([['a', [2, 1]]])
equal(x, y) // true
// empty maps equal those with data b/c the key set is empty and the check falls all the way though the ifs
const z = new Map()
equal(a, z) // true
```

While `Map`s don't have good [browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Browser_compatibility) at this time, they are useful in Node, and I've found that I want tape's `deepEqual`, `deepLooseEqual`, and friends to work properly with `Map`s when testing Node applications.

The implementation is a near duplication of the `Object` handling code, but deduplicating that didn't seem straightforward or all that beneficial to me at the time.

I also made a few small changes to make the style more consistent, and added a .gitignore, but tried to not overreach or get too out of scope. I can revert these changes upon request.