### PR TITLE
Drop unnecessary `regexp.prototype.flags`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var objectKeys = require('object-keys');
 var isArguments = require('is-arguments');
 var is = require('object-is');
 var isRegex = require('is-regex');
-var flags = require('regexp.prototype.flags');
 var isArray = require('isarray');
 var isDate = require('is-date-object');
 var whichBoxedPrimitive = require('which-boxed-primitive');
@@ -294,7 +293,7 @@ function objEquiv(a, b, opts, channel) {
   var aIsRegex = isRegex(a);
   var bIsRegex = isRegex(b);
   if (aIsRegex !== bIsRegex) { return false; }
-  if ((aIsRegex || bIsRegex) && (a.source !== b.source || flags(a) !== flags(b))) {
+  if ((aIsRegex || bIsRegex) && (a.source !== b.source || a.flags !== b.flags)) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "object-is": "^1.1.4",
     "object-keys": "^1.1.1",
     "object.assign": "^4.1.2",
-    "regexp.prototype.flags": "^1.3.0",
     "side-channel": "^1.0.3",
     "which-boxed-primitive": "^1.0.1",
     "which-collection": "^1.0.1",


### PR DESCRIPTION
https://github.com/inspect-js/node-deep-equal/commit/b8c179c5aa91c8a2f71f053e2d9e2d477780250e introduced this [heavy-ish](https://packagephobia.com/result?p=regexp.prototype.flags) dependency but it didn't explain why. Tests pass without it as the property has been supported forever.