### PR TITLE
Remove obvious dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var objectKeys = require('object-keys');
 var isArguments = require('is-arguments');
-var is = require('object-is');
 var isRegex = require('is-regex');
 var flags = require('regexp.prototype.flags');
 var isDate = require('is-date-object');
@@ -129,7 +128,7 @@ function internalDeepEqual(actual, expected, options, channel) {
   var opts = options || {};
 
   // 7.1. All identical values are equivalent, as determined by ===.
-  if (opts.strict ? is(actual, expected) : actual === expected) {
+  if (opts.strict ? Object.is(actual, expected) : actual === expected) {
     return true;
   }
 
@@ -141,7 +140,7 @@ function internalDeepEqual(actual, expected, options, channel) {
 
   // 7.3. Other pairs that do not both pass typeof value == 'object', equivalence is determined by ==.
   if (!actual || !expected || (typeof actual !== 'object' && typeof expected !== 'object')) {
-    return opts.strict ? is(actual, expected) : actual == expected; // eslint-disable-line eqeqeq
+    return opts.strict ? Object.is(actual, expected) : actual == expected; // eslint-disable-line eqeqeq
   }
 
   /*

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ var whichCollection = require('which-collection');
 var getIterator = require('es-get-iterator');
 var getSideChannel = require('side-channel');
 var whichTypedArray = require('which-typed-array');
-var assign = require('object.assign');
 
 // TODO: use extracted package
 var byteLength = callBound('ArrayBuffer.prototype.byteLength', true);
@@ -80,7 +79,7 @@ function mapMightHaveLoosePrim(a, b, prim, item, opts, channel) {
     return altValue;
   }
   var curB = $mapGet(b, altValue);
-  var looseOpts = assign({}, opts, { strict: false });
+  var looseOpts = Object.assign({}, opts, { strict: false });
   if (
     (typeof curB === 'undefined' && !$mapHas(b, altValue))
     // eslint-disable-next-line no-use-before-define
@@ -269,7 +268,7 @@ function mapEquiv(a, b, opts, channel) {
       } else if (
         !opts.strict
         && (!a.has(key) || !internalDeepEqual($mapGet(a, key), item2, opts, channel))
-        && !mapHasEqualEntry(set, a, key, item2, assign({}, opts, { strict: false }), channel)
+        && !mapHasEqualEntry(set, a, key, item2, Object.assign({}, opts, { strict: false }), channel)
       ) {
         return false;
       }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var objectKeys = require('object-keys');
 var isArguments = require('is-arguments');
 var isRegex = require('is-regex');
 var flags = require('regexp.prototype.flags');
@@ -344,8 +343,8 @@ function objEquiv(a, b, opts, channel) {
 
   if (typeof a !== typeof b) { return false; }
 
-  var ka = objectKeys(a);
-  var kb = objectKeys(b);
+  var ka = Object.keys(a);
+  var kb = Object.keys(b);
   // having the same number of owned properties (keys incorporates hasOwnProperty)
   if (ka.length !== kb.length) { return false; }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var isArguments = require('is-arguments');
 var is = require('object-is');
 var isRegex = require('is-regex');
 var flags = require('regexp.prototype.flags');
-var isArray = require('isarray');
 var isDate = require('is-date-object');
 var whichBoxedPrimitive = require('which-boxed-primitive');
 var GetIntrinsic = require('get-intrinsic');
@@ -293,8 +292,8 @@ function objEquiv(a, b, opts, channel) {
 
   if (isArguments(a) !== isArguments(b)) { return false; }
 
-  var aIsArray = isArray(a);
-  var bIsArray = isArray(b);
+  var aIsArray = Array.isArray(a);
+  var bIsArray = Array.isArray(b);
   if (aIsArray !== bIsArray) { return false; }
 
   // TODO: replace when a cross-realm brand check is available

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "is-arguments": "^1.1.1",
     "is-date-object": "^1.0.5",
     "is-regex": "^1.1.4",
-    "object.assign": "^4.1.2",
     "regexp.prototype.flags": "^1.3.1",
     "side-channel": "^1.0.4",
     "which-boxed-primitive": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "is-arguments": "^1.1.1",
     "is-date-object": "^1.0.5",
     "is-regex": "^1.1.4",
-    "object-keys": "^1.1.1",
     "object.assign": "^4.1.2",
     "regexp.prototype.flags": "^1.3.1",
     "side-channel": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "is-arguments": "^1.1.1",
     "is-date-object": "^1.0.5",
     "is-regex": "^1.1.4",
-    "isarray": "^2.0.5",
     "object-is": "^1.1.5",
     "object-keys": "^1.1.1",
     "object.assign": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "is-arguments": "^1.1.1",
     "is-date-object": "^1.0.5",
     "is-regex": "^1.1.4",
-    "object-is": "^1.1.5",
     "object-keys": "^1.1.1",
     "object.assign": "^4.1.2",
     "regexp.prototype.flags": "^1.3.1",

--- a/test/_tape.js
+++ b/test/_tape.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Test = require('tape/lib/test');
-var is = require('object-is');
 
 var deepEqual = require('../');
 var assert = require('../assert');
@@ -25,7 +24,7 @@ function equalReversed(t, a, b, isEqual, msg, isStrict, skipReversed) {
     : equal(a, b);
   var suffix = isEqual ? ' are equal' : ' are not equal';
   t.equal(actual, !!isEqual, msg + suffix);
-  if (typeof skipReversed === 'boolean' ? !skipReversed : !is(a, b)) {
+  if (typeof skipReversed === 'boolean' ? !skipReversed : !Object.is(a, b)) {
     var actualReverse = isStrict
       ? equal(b, a, { strict: true })
       : equal(b, a);

--- a/test/cmp.js
+++ b/test/cmp.js
@@ -2,7 +2,6 @@
 
 var test = require('tape');
 require('./_tape');
-var assign = require('object.assign');
 var gOPDs = require('object.getownpropertydescriptors');
 var hasSymbols = require('has-symbols')();
 var hasTypedArrays = require('has-typed-arrays')();
@@ -923,7 +922,7 @@ test('Errors', function (t) {
 
   t.deepEqualTest(
     new Error('a'),
-    assign(new Error('a'), { code: 10 }),
+    Object.assign(new Error('a'), { code: 10 }),
     'two otherwise equal errors with different own properties',
     false,
     false
@@ -1139,7 +1138,7 @@ test('TypedArrays', { skip: !hasTypedArrays }, function (t) {
     var a = safeBuffer('test');
     var b = tag(Object.create(
       a.__proto__, // eslint-disable-line no-proto
-      assign(gOPDs(a), {
+      Object.assign(gOPDs(a), {
         length: {
           enumerable: false,
           value: 4


### PR DESCRIPTION
Motivation:

A lot of tools depend on this project so down the line a lot of additional dependencies need to be audited and checked. In the case of some tooling like `node2nix` this slows everything down. The dependencies I've removed have been in Node and browsers for years. I hope that this could just be seen as a starting point and that I hope even more deps can be stripped too!